### PR TITLE
Progressive authentication helper

### DIFF
--- a/packages/onegraph-auth/README.md
+++ b/packages/onegraph-auth/README.md
@@ -1,16 +1,3 @@
 ## OneGraph Auth
 
-### Supported services
-
-  - eventil
-  - github
-  - gmail
-  - google
-  - google-compute
-  - google-docs
-  - salesforce
-  - stripe
-  - twilio
-  - twitter
-  - youtube
-  - zendesk
+The main helper library for automating all-things authentication in the browser. Many services are supported for logging in/out of applications, and more details about the library can be found on [the OneGraph docs site](https://www.onegraph.com/docs/authentication.html).

--- a/packages/onegraph-auth/package.json
+++ b/packages/onegraph-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onegraph-auth",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Auth helpers for OneGraph",
   "homepage": "https://github.com/OneGraph/onegraph-client/tree/master/packages/onegraph-auth",
   "main": "dist/bundle.umd.js",

--- a/packages/onegraph-auth/package.json
+++ b/packages/onegraph-auth/package.json
@@ -1,8 +1,9 @@
 {
   "name": "onegraph-auth",
-  "version": "2.0.6",
+  "version": "2.0.5",
   "description": "Auth helpers for OneGraph",
-  "homepage": "https://github.com/OneGraph/onegraph-client/tree/master/packages/onegraph-auth",
+  "homepage":
+    "https://github.com/OneGraph/onegraph-client/tree/master/packages/onegraph-auth",
   "main": "dist/bundle.umd.js",
   "module": "dist/bundle.es.js",
   "license": "MIT",

--- a/packages/onegraph-auth/src/auth.js
+++ b/packages/onegraph-auth/src/auth.js
@@ -395,7 +395,7 @@ function tokenFromStorage(storage: Storage, appId: string): ?Token {
   return null;
 }
 
-const findMissingAuthService = results => {
+function findMissingAuthServices(results) {
   /* Detect and normalize between:
   1. The full graphql result
   2. The `result.errors` of a graphql result
@@ -412,20 +412,19 @@ const findMissingAuthService = results => {
 
   // If errors aren't an array, bail
   if (!Array.isArray(errors)) {
-    return null;
+    return [];
   }
 
-  const missingServiceError = errors.filter(
-    error => error.extensions.type === 'auth/missing-auth',
-  )[0];
+  const missingServiceErrors = errors.filter(
+    error => idx(error, _ => _.extensions.type) === 'auth/missing-auth',
+  );
 
-  const missingService =
-    missingServiceError &&
-    missingServiceError.extensions &&
-    missingServiceError.extensions.service;
+  const missingServices = missingServiceErrors
+    .map(error => idx(error, _ => _.extensions.service))
+    .filter(Boolean);
 
-  return missingService;
-};
+  return missingServices;
+}
 
 const DEFAULT_ONEGRAPH_ORIGIN = 'https://serve.onegraph.com';
 
@@ -832,7 +831,7 @@ class OneGraphAuth {
     this._storage.removeItem(this._storageKey);
   };
 
-  findMissingAuthService = findMissingAuthService;
+  findMissingAuthServices = findMissingAuthServices;
 }
 
 export default OneGraphAuth;


### PR DESCRIPTION
Adds `findMissingAuthService` to be used like:

```
  const serviceName = auth.findMissingAuthService(errors);

    if (serviceName) {
      // Automatic progressive authentication!
      // -------------------------------------
      // If we detected missing auth in the last call, then
      // ask the user to log into the missing service
      // to complete our query/mutation.
      // Note: that this will open a popup window, so it
      // should really only be called in response to a user action
      // (like the onClick handler for a login button)
      console.warn("Missing auth for service: ", serviceName);
      await auth.login(serviceName);
    } else if (errors) {
      // handle errors from OneGraph and various APIs
      console.error(errors);
    }
```

The function tries to extract the correct auth errors from whatever a user might pass in