### PR TITLE
Remove window.auth

### DIFF
--- a/packages/react-onegraph/src/index.js
+++ b/packages/react-onegraph/src/index.js
@@ -15,8 +15,6 @@ class AuthProvider extends Component {
       appId: this.props.appId,
     });
 
-    window.auth = auth;
-
     auth.servicesStatus().then(status =>
       this.setState({
         headers: auth.authHeaders(),


### PR DESCRIPTION
Just found this line which was solely for testing purposes.
Might clash with other auth tools using the same namespace and we simply don't need it here.