### PR TITLE
Allow fetch implementation to optionally be passed in

### DIFF
--- a/packages/onegraph-subscription-client/src/OneGraphSubscriptionClient.js
+++ b/packages/onegraph-subscription-client/src/OneGraphSubscriptionClient.js
@@ -7,13 +7,25 @@ import {SubscriptionClient} from 'subscriptions-transport-ws/dist/client';
 
 import type {OneGraphAuth} from 'onegraph-auth';
 
-function getConnectionParams() {
+export type Options = {
+  host?: ?string,
+  oneGraphAuth?: ?OneGraphAuth,
+  timeout?: number,
+  lazy?: boolean,
+  reconnect?: boolean,
+  reconnectionAttempts?: number,
+  connectionCallback?: (?Error) => {},
+  inactivityTimeout?: number,
+  fetchImpl?: any,
+};
+
+function getConnectionParams(options: ?Options) {
   return new Promise(function (resolve, reject) {
     const sessionId = uuid();
     if (sessionId) {
       resolve({sessionId});
     } else {
-      fetchUuid()
+      fetchUuid(options)
         .then(function (uuid) {
           if (!uuid) {
             reject(
@@ -48,17 +60,6 @@ function middleware(auth: ?OneGraphAuth) {
   ];
 }
 
-type Options = {
-  host?: ?string,
-  oneGraphAuth?: ?OneGraphAuth,
-  timeout?: number,
-  lazy?: boolean,
-  reconnect?: boolean,
-  reconnectionAttempts?: number,
-  connectionCallback?: (?Error) => {},
-  inactivityTimeout?: number,
-};
-
 class OneGraphSubscriptionClient extends SubscriptionClient<
   string,
   ?Options,
@@ -91,7 +92,7 @@ class OneGraphSubscriptionClient extends SubscriptionClient<
       `wss://${host}/ws?app_id=${appId}`,
       {
         ...(options || {}),
-        connectionParams: getConnectionParams(),
+        connectionParams: getConnectionParams(options),
       },
       webSocketImpl,
       webSocketProtocols,

--- a/packages/onegraph-subscription-client/src/fetch.js
+++ b/packages/onegraph-subscription-client/src/fetch.js
@@ -1,10 +1,12 @@
 // @flow
+import type {Options} from './OneGraphSubscriptionClient';
 
-export function fetchUuid(): Promise<?string> {
-  if (typeof fetch !== 'undefined') {
-    return fetch('https://serve.onegraph.com/uuid', {
+export function fetchUuid(options: ?Options): Promise<?string> {
+  const fetchFn = (options && options.fetchImpl) || fetch;
+  if (typeof fetchFn !== 'undefined') {
+    return fetchFn('https://serve.onegraph.com/uuid', {
       method: 'POST',
-    }).then(function(r) {
+    }).then(function (r) {
       return r.text();
     });
   } else if (typeof global.https !== 'undefined' && global.https.request) {
@@ -16,13 +18,13 @@ export function fetchUuid(): Promise<?string> {
           path: '/uuid',
           method: 'POST',
         },
-        res => {
-          res.on('data', d => {
+        (res) => {
+          res.on('data', (d) => {
             resolve(d.toString('utf-8'));
           });
         },
       );
-      req.on('error', e => {
+      req.on('error', (e) => {
         reject(
           new Error(
             'Unable to generate sessionId to start subscription client.',


### PR DESCRIPTION
Falls back to the globally-available `fetch`, but also allows a user-specified `fetch` function to be provided.